### PR TITLE
Async optimization, bug fixes, and UDP support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,9 +45,9 @@ http = "1"
 tower = { version = "0.5", default-features = false }
 
 # crate in this workspace
-dpdk-net = { path = "dpdk-net", version = "0.1.0" }
-dpdk-net-util = { path = "dpdk-net-util", version = "0.1.0" }
-dpdk-net-axum = { path = "dpdk-net-axum", version = "0.1.0" }
-dpdk-net-tonic = { path = "dpdk-net-tonic", version = "0.1.0" }
-dpdk-net-sys = { path = "dpdk-net-sys", version = "0.1.0" }
+dpdk-net = { path = "dpdk-net" }
+dpdk-net-util = { path = "dpdk-net-util" }
+dpdk-net-axum = { path = "dpdk-net-axum" }
+dpdk-net-tonic = { path = "dpdk-net-tonic" }
+dpdk-net-sys = { path = "dpdk-net-sys" }
 dpdk-net-test = { path = "dpdk-net-test" }

--- a/dpdk-net-test/tests/udp_echo_dpdk_app_test.rs
+++ b/dpdk-net-test/tests/udp_echo_dpdk_app_test.rs
@@ -1,0 +1,132 @@
+//! UDP Echo Test using DpdkApp
+//!
+//! End-to-end test that verifies UDP send_to + recv_from works through the
+//! full DPDK stack using the DpdkApp runner. Also exercises the new
+//! `bind_default`, `connect`, `send`, and `recv` APIs.
+
+use dpdk_net::api::rte::eal::EalBuilder;
+use dpdk_net::socket::UdpSocket;
+use dpdk_net_axum::{DpdkApp, WorkerContext};
+use serial_test::serial;
+use smoltcp::wire::{IpAddress, IpEndpoint, Ipv4Address};
+
+const IP: Ipv4Address = Ipv4Address::new(192, 168, 1, 1);
+const GATEWAY: Ipv4Address = Ipv4Address::new(192, 168, 1, 254);
+const SERVER_PORT: u16 = 9000;
+const CLIENT_PORT: u16 = 9001;
+
+#[test]
+#[serial]
+fn test_udp_echo_via_dpdk_app() {
+    println!("\n=== UDP Echo DpdkApp Test ===\n");
+
+    let _eal = EalBuilder::new()
+        .no_huge()
+        .no_pci()
+        .in_memory()
+        .core_list("0")
+        .vdev("net_ring0")
+        .init()
+        .expect("Failed to initialize EAL");
+
+    DpdkApp::new()
+        .eth_dev(0)
+        .ip(IP)
+        .gateway(GATEWAY)
+        .mbufs_per_queue(1024)
+        .descriptors(128, 128)
+        .run(|ctx: WorkerContext| async move {
+            // Test 1: Basic send_to / recv_from
+            {
+                let server = UdpSocket::bind_default(&ctx.reactor, SERVER_PORT)
+                    .expect("Failed to bind server");
+                let client = UdpSocket::bind_default(&ctx.reactor, CLIENT_PORT)
+                    .expect("Failed to bind client");
+
+                let server_ep = IpEndpoint::new(IpAddress::Ipv4(IP), SERVER_PORT);
+
+                // Send from client to server
+                let sent = client.send_to(b"hello udp", server_ep).await.unwrap();
+                assert_eq!(sent, 9);
+                println!("Client sent {} bytes", sent);
+
+                // Yield to let reactor process
+                tokio::task::yield_now().await;
+                tokio::task::yield_now().await;
+
+                // Server receives
+                let mut buf = [0u8; 256];
+                let (n, meta) = server.recv_from(&mut buf).await.unwrap();
+                assert_eq!(&buf[..n], b"hello udp");
+                println!("Server received: {:?}", std::str::from_utf8(&buf[..n]));
+
+                // Server echoes back
+                let sent = server.send_to(&buf[..n], meta.endpoint).await.unwrap();
+                assert_eq!(sent, 9);
+
+                // Yield to let reactor process
+                tokio::task::yield_now().await;
+                tokio::task::yield_now().await;
+
+                // Client receives echo
+                let (n2, _) = client.recv_from(&mut buf).await.unwrap();
+                assert_eq!(&buf[..n2], b"hello udp");
+                println!("Client received echo: {:?}", std::str::from_utf8(&buf[..n2]));
+                println!("Test 1 (send_to/recv_from) PASSED");
+            }
+
+            // Test 2: Connected mode (connect + send/recv)
+            {
+                let mut server = UdpSocket::bind_default(&ctx.reactor, SERVER_PORT + 10)
+                    .expect("Failed to bind server");
+                let mut client = UdpSocket::bind_default(&ctx.reactor, CLIENT_PORT + 10)
+                    .expect("Failed to bind client");
+
+                let server_ep = IpEndpoint::new(IpAddress::Ipv4(IP), SERVER_PORT + 10);
+                let client_ep = IpEndpoint::new(IpAddress::Ipv4(IP), CLIENT_PORT + 10);
+
+                client.connect(server_ep);
+                server.connect(client_ep);
+
+                assert_eq!(client.peer_endpoint(), Some(server_ep));
+                assert_eq!(server.peer_endpoint(), Some(client_ep));
+
+                // Send via connected mode
+                let sent = client.send(b"connected!").await.unwrap();
+                assert_eq!(sent, 10);
+
+                tokio::task::yield_now().await;
+                tokio::task::yield_now().await;
+
+                // Receive via connected mode (no metadata)
+                let mut buf = [0u8; 256];
+                let n = server.recv(&mut buf).await.unwrap();
+                assert_eq!(&buf[..n], b"connected!");
+                println!("Test 2 (connected mode) PASSED");
+            }
+
+            // Test 3: WorkerContext helpers
+            {
+                let socket = ctx.bind_udp(SERVER_PORT + 20).expect("Failed to bind via ctx");
+                assert!(socket.is_open());
+                assert_eq!(socket.endpoint().port, SERVER_PORT + 20);
+
+                let socket2 = ctx.bind_udp_with_buffers(SERVER_PORT + 21, 32, 32, 1500)
+                    .expect("Failed to bind via ctx with custom buffers");
+                assert!(socket2.is_open());
+                println!("Test 3 (WorkerContext helpers) PASSED");
+            }
+
+            // Test 4: Ephemeral port allocation
+            {
+                let port1 = ctx.alloc_ephemeral_port();
+                let port2 = ctx.alloc_ephemeral_port();
+                assert_ne!(port1, port2);
+                assert!(port1 >= 32768);
+                assert!(port2 >= 32768);
+                println!("Test 4 (ephemeral ports: {}, {}) PASSED", port1, port2);
+            }
+
+            println!("\n=== All UDP DpdkApp Tests PASSED ===\n");
+        });
+}

--- a/dpdk-net-util/Cargo.toml
+++ b/dpdk-net-util/Cargo.toml
@@ -14,7 +14,7 @@ smoltcp.workspace = true
 hyper = { workspace = true, features = ["client", "http1", "http2"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 http-body-util.workspace = true
-tokio = { workspace = true, features = ["rt"] }
+tokio = { workspace = true, features = ["rt", "time"] }
 tracing.workspace = true
 
 [dev-dependencies]

--- a/dpdk-net-util/src/app.rs
+++ b/dpdk-net-util/src/app.rs
@@ -70,7 +70,37 @@ pub struct DpdkApp {
     mbufs_per_queue: u32,
     rx_desc: u16,
     tx_desc: u16,
+    subnet_prefix: u8,
 }
+
+/// Errors returned by [`DpdkApp::try_run`].
+#[derive(Debug)]
+pub enum DpdkAppError {
+    /// IP address was not configured.
+    MissingIpAddress,
+    /// Gateway was not configured.
+    MissingGateway,
+    /// No lcores available.
+    NoLcores,
+    /// Failed to query or configure the Ethernet device.
+    DeviceError(String),
+    /// Failed to create mempool.
+    MempoolError(String),
+}
+
+impl std::fmt::Display for DpdkAppError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingIpAddress => write!(f, "IP address not set. Call ip() before run()"),
+            Self::MissingGateway => write!(f, "Gateway not set. Call gateway() before run()"),
+            Self::NoLcores => write!(f, "No lcores available. Ensure EAL is initialized with -l flag"),
+            Self::DeviceError(e) => write!(f, "Device error: {e}"),
+            Self::MempoolError(e) => write!(f, "Mempool error: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for DpdkAppError {}
 
 impl Default for DpdkApp {
     fn default() -> Self {
@@ -88,6 +118,7 @@ impl DpdkApp {
             mbufs_per_queue: 8192,
             rx_desc: 1024,
             tx_desc: 1024,
+            subnet_prefix: 24,
         }
     }
 
@@ -122,6 +153,12 @@ impl DpdkApp {
         self
     }
 
+    /// Set subnet prefix length (default: 24, i.e., /24).
+    pub fn subnet_prefix(mut self, prefix: u8) -> Self {
+        self.subnet_prefix = prefix;
+        self
+    }
+
     /// Run the application.
     ///
     /// Launches work on all worker lcores and runs queue 0 on the main lcore.
@@ -144,19 +181,30 @@ impl DpdkApp {
         F: Fn(WorkerContext) -> Fut + Send + Sync + 'static,
         Fut: Future<Output = ()> + 'static,
     {
-        let ip_addr = self
-            .ip_addr
-            .expect("IP address not set. Call ip() before run()");
-        let gateway = self
-            .gateway
-            .expect("Gateway not set. Call gateway() before run()");
+        if let Err(e) = self.try_run(server) {
+            panic!("{e}");
+        }
+    }
+
+    /// Run the application, returning errors instead of panicking.
+    ///
+    /// This is the fallible version of [`run`](Self::run). See its documentation
+    /// for details on behavior.
+    pub fn try_run<F, Fut>(self, server: F) -> Result<(), DpdkAppError>
+    where
+        F: Fn(WorkerContext) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + 'static,
+    {
+        let ip_addr = self.ip_addr.ok_or(DpdkAppError::MissingIpAddress)?;
+        let gateway = self.gateway.ok_or(DpdkAppError::MissingGateway)?;
+        let subnet_prefix = self.subnet_prefix;
 
         // Collect lcores
         let lcores: Vec<Lcore> = Lcore::all().collect();
         let num_queues = lcores.len();
 
         if num_queues == 0 {
-            panic!("No lcores available. Ensure EAL is initialized with -l flag.");
+            return Err(DpdkAppError::NoLcores);
         }
 
         info!(
@@ -164,13 +212,14 @@ impl DpdkApp {
             port_id = self.port_id,
             ip = %ip_addr,
             %gateway,
+            subnet_prefix,
             "DpdkApp starting"
         );
 
         // Query device info
         let dev_info = EthDev::new(self.port_id)
             .info()
-            .expect("Failed to get device info");
+            .map_err(|e| DpdkAppError::DeviceError(format!("{e:?}")))?;
         let reta_size = dev_info.reta_size as usize;
 
         // Create mempool
@@ -180,13 +229,14 @@ impl DpdkApp {
             .data_room_size(DEFAULT_MBUF_DATA_ROOM_SIZE);
 
         let mempool = Arc::new(
-            MemPool::create("dpdk_app_pool", &mempool_config).expect("Failed to create mempool"),
+            MemPool::create("dpdk_app_pool", &mempool_config)
+                .map_err(|e| DpdkAppError::MempoolError(format!("{e:?}")))?,
         );
 
-        // Configure ethernet device with RSS if supported
+        // Configure ethernet device with RSS for both TCP and UDP if supported
         let eth_conf = if reta_size > 0 && num_queues > 1 {
-            info!(reta_size, "Enabling RSS for multi-queue");
-            EthConf::new().rss_with_hash(rss_hf::NONFRAG_IPV4_TCP | rss_hf::NONFRAG_IPV6_TCP)
+            info!(reta_size, "Enabling RSS for multi-queue (TCP + UDP)");
+            EthConf::new().rss_with_hash(rss_hf::TCP | rss_hf::UDP)
         } else {
             if num_queues > 1 {
                 warn!(
@@ -203,10 +253,12 @@ impl DpdkApp {
             .rx_queue_conf(RxQueueConf::new().nb_desc(self.rx_desc))
             .tx_queue_conf(TxQueueConf::new().nb_desc(self.tx_desc))
             .build(&mempool)
-            .expect("Failed to configure ethernet device");
+            .map_err(|e| DpdkAppError::DeviceError(format!("{e:?}")))?;
 
         // Get MAC address
-        let mac = eth_dev.mac_addr().expect("Failed to get MAC address");
+        let mac = eth_dev
+            .mac_addr()
+            .map_err(|e| DpdkAppError::DeviceError(format!("{e:?}")))?;
         let mac_addr = EthernetAddress(mac.addr_bytes);
 
         info!(
@@ -253,12 +305,13 @@ impl DpdkApp {
                         mac_addr,
                         ip_addr,
                         gateway,
+                        subnet_prefix,
                         shared_arp_cache,
                         server,
                     );
                     0
                 })
-                .expect("Failed to launch on worker lcore");
+                .map_err(|e| DpdkAppError::DeviceError(format!("Failed to launch lcore: {e:?}")))?;
         }
 
         // Run main queue on main lcore
@@ -269,6 +322,7 @@ impl DpdkApp {
             mac_addr,
             ip_addr,
             gateway,
+            subnet_prefix,
             shared_arp_cache,
             server,
         );
@@ -284,6 +338,7 @@ impl DpdkApp {
         drop(mempool);
 
         info!("DpdkApp shutdown complete");
+        Ok(())
     }
 
     /// Run a single worker on the current lcore.
@@ -295,6 +350,7 @@ impl DpdkApp {
         mac_addr: EthernetAddress,
         ip_addr: Ipv4Address,
         gateway: Ipv4Address,
+        subnet_prefix: u8,
         shared_arp_cache: Option<SharedArpCache>,
         server: Arc<F>,
     ) where
@@ -335,13 +391,13 @@ impl DpdkApp {
 
         iface.update_ip_addrs(|ip_addrs| {
             ip_addrs
-                .push(IpCidr::new(IpAddress::Ipv4(ip_addr), 24))
+                .push(IpCidr::new(IpAddress::Ipv4(ip_addr), subnet_prefix))
                 .unwrap();
         });
         iface.routes_mut().add_default_ipv4_route(gateway).unwrap();
 
         // Create tokio runtime
-        let rt = Builder::new_current_thread().build().unwrap();
+        let rt = Builder::new_current_thread().enable_all().build().unwrap();
         let local = tokio::task::LocalSet::new();
 
         local.block_on(&rt, async {
@@ -359,12 +415,7 @@ impl DpdkApp {
             });
 
             // Create worker context
-            let ctx = WorkerContext {
-                lcore,
-                queue_id,
-                socket_id: lcore.socket_id(),
-                reactor: handle,
-            };
+            let ctx = WorkerContext::new(lcore, queue_id, lcore.socket_id(), handle);
 
             // Run user's server/client
             server(ctx).await;

--- a/dpdk-net-util/src/client.rs
+++ b/dpdk-net-util/src/client.rs
@@ -93,32 +93,34 @@ impl DpdkHttpClient {
         port: u16,
         local_port: u16,
     ) -> Result<Connection, Error> {
-        let fut = match self.config.http_version {
-            HttpVersion::Http1 => {
-                Connection::http1(
-                    &self.reactor,
-                    addr,
-                    port,
-                    local_port,
-                    self.config.rx_buffer_size,
-                    self.config.tx_buffer_size,
-                )
+        tokio::time::timeout(self.config.connect_timeout, async {
+            match self.config.http_version {
+                HttpVersion::Http1 => {
+                    Connection::http1(
+                        &self.reactor,
+                        addr,
+                        port,
+                        local_port,
+                        self.config.rx_buffer_size,
+                        self.config.tx_buffer_size,
+                    )
+                    .await
+                }
+                HttpVersion::Http2 => {
+                    Connection::http2(
+                        &self.reactor,
+                        addr,
+                        port,
+                        local_port,
+                        self.config.rx_buffer_size,
+                        self.config.tx_buffer_size,
+                    )
+                    .await
+                }
             }
-            HttpVersion::Http2 => {
-                Connection::http2(
-                    &self.reactor,
-                    addr,
-                    port,
-                    local_port,
-                    self.config.rx_buffer_size,
-                    self.config.tx_buffer_size,
-                )
-            }
-        };
-
-        tokio::time::timeout(self.config.connect_timeout, fut)
-            .await
-            .map_err(|_| Error::ConnectTimeout)?
+        })
+        .await
+        .map_err(|_| Error::ConnectTimeout)?
     }
 
     /// Send a one-shot HTTP request, creating a new connection.

--- a/dpdk-net-util/src/client.rs
+++ b/dpdk-net-util/src/client.rs
@@ -18,7 +18,7 @@ pub struct ClientConfig {
     pub tx_buffer_size: usize,
     /// HTTP version preference.
     pub http_version: HttpVersion,
-    /// Connection timeout (not yet enforced — reserved for future use).
+    /// Connection timeout. Applied to TCP connect + HTTP handshake.
     pub connect_timeout: Duration,
 }
 
@@ -83,13 +83,17 @@ impl DpdkHttpClient {
     ///
     /// `local_port` is the ephemeral source port for the TCP connection.
     /// The HTTP version is determined by [`ClientConfig::http_version`].
+    ///
+    /// The connection attempt (TCP handshake + HTTP handshake) is bounded by
+    /// [`ClientConfig::connect_timeout`]. Returns [`Error::ConnectTimeout`] if
+    /// the timeout expires.
     pub async fn connect(
         &self,
         addr: IpAddress,
         port: u16,
         local_port: u16,
     ) -> Result<Connection, Error> {
-        match self.config.http_version {
+        let fut = match self.config.http_version {
             HttpVersion::Http1 => {
                 Connection::http1(
                     &self.reactor,
@@ -99,7 +103,6 @@ impl DpdkHttpClient {
                     self.config.rx_buffer_size,
                     self.config.tx_buffer_size,
                 )
-                .await
             }
             HttpVersion::Http2 => {
                 Connection::http2(
@@ -110,9 +113,12 @@ impl DpdkHttpClient {
                     self.config.rx_buffer_size,
                     self.config.tx_buffer_size,
                 )
-                .await
             }
-        }
+        };
+
+        tokio::time::timeout(self.config.connect_timeout, fut)
+            .await
+            .map_err(|_| Error::ConnectTimeout)?
     }
 
     /// Send a one-shot HTTP request, creating a new connection.

--- a/dpdk-net-util/src/context.rs
+++ b/dpdk-net-util/src/context.rs
@@ -2,12 +2,22 @@
 
 use dpdk_net::api::rte::lcore::Lcore;
 use dpdk_net::runtime::ReactorHandle;
+use dpdk_net::socket::{TcpListener, UdpSocket};
+use smoltcp::socket::tcp::ListenError;
+use smoltcp::socket::udp::BindError as UdpBindError;
+use std::cell::Cell;
+
+/// Start of the ephemeral port range.
+const EPHEMERAL_PORT_START: u16 = 32768;
+/// End of the ephemeral port range (inclusive).
+const EPHEMERAL_PORT_END: u16 = 60999;
 
 /// Context passed to each worker lcore.
 ///
 /// This provides everything needed to run a server or client on a specific lcore:
 /// - Access to the lcore information (ID, socket, etc.)
 /// - Reactor handle for creating TCP/UDP sockets
+/// - Ephemeral port allocator for client connections
 ///
 /// # Example
 ///
@@ -16,8 +26,8 @@ use dpdk_net::runtime::ReactorHandle;
 /// use dpdk_net::socket::TcpListener;
 ///
 /// async fn my_server(ctx: WorkerContext) {
-///     // Create a server listener
-///     let listener = TcpListener::bind(&ctx.reactor, 8080, 4096, 4096).unwrap();
+///     // Create a server listener with default buffer sizes
+///     let listener = ctx.bind_tcp(8080).unwrap();
 ///     // ... serve requests
 /// }
 /// ```
@@ -39,4 +49,64 @@ pub struct WorkerContext {
     ///
     /// Use this to create `TcpListener` (server) or `TcpStream` (client).
     pub reactor: ReactorHandle,
+
+    /// Per-lcore ephemeral port counter (starts offset by queue_id to avoid collisions).
+    next_ephemeral_port: Cell<u16>,
+}
+
+impl WorkerContext {
+    /// Create a new WorkerContext.
+    pub(crate) fn new(lcore: Lcore, queue_id: u16, socket_id: u32, reactor: ReactorHandle) -> Self {
+        // Offset starting port by queue_id to reduce inter-queue collisions
+        let start = EPHEMERAL_PORT_START + (queue_id as u16 % 100) * 256;
+        Self {
+            lcore,
+            queue_id,
+            socket_id,
+            reactor,
+            next_ephemeral_port: Cell::new(start),
+        }
+    }
+
+    /// Allocate the next ephemeral port for a client TCP connection.
+    ///
+    /// Each lcore has its own counter, starting at a queue-specific offset
+    /// to reduce collisions. Wraps around within the ephemeral range.
+    pub fn alloc_ephemeral_port(&self) -> u16 {
+        let port = self.next_ephemeral_port.get();
+        let next = if port >= EPHEMERAL_PORT_END {
+            EPHEMERAL_PORT_START
+        } else {
+            port + 1
+        };
+        self.next_ephemeral_port.set(next);
+        port
+    }
+
+    /// Bind a TCP listener on the given port with default buffer sizes (16KB rx/tx, backlog 2).
+    pub fn bind_tcp(&self, port: u16) -> Result<TcpListener, ListenError> {
+        TcpListener::bind(&self.reactor, port, 16384, 16384)
+    }
+
+    /// Bind a UDP socket on the given port with default buffer sizes (64 packets, 1536 bytes each).
+    pub fn bind_udp(&self, port: u16) -> Result<UdpSocket, UdpBindError> {
+        UdpSocket::bind(&self.reactor, port, 64, 64, 1536)
+    }
+
+    /// Bind a UDP socket with custom buffer sizes.
+    pub fn bind_udp_with_buffers(
+        &self,
+        port: u16,
+        rx_buffer_packets: usize,
+        tx_buffer_packets: usize,
+        max_packet_size: usize,
+    ) -> Result<UdpSocket, UdpBindError> {
+        UdpSocket::bind(
+            &self.reactor,
+            port,
+            rx_buffer_packets,
+            tx_buffer_packets,
+            max_packet_size,
+        )
+    }
 }

--- a/dpdk-net-util/src/error.rs
+++ b/dpdk-net-util/src/error.rs
@@ -7,6 +7,8 @@ pub enum Error {
     Connect(smoltcp::socket::tcp::ConnectError),
     /// The TCP connection was refused or timed out.
     ConnectionFailed,
+    /// The connection attempt exceeded the configured timeout.
+    ConnectTimeout,
     /// HTTP handshake failed.
     Handshake(hyper::Error),
     /// Sending a request failed.
@@ -22,6 +24,7 @@ impl fmt::Display for Error {
         match self {
             Error::Connect(e) => write!(f, "TCP connect error: {e}"),
             Error::ConnectionFailed => write!(f, "TCP connection failed"),
+            Error::ConnectTimeout => write!(f, "TCP connection timed out"),
             Error::Handshake(e) => write!(f, "HTTP handshake error: {e}"),
             Error::Request(e) => write!(f, "HTTP request error: {e}"),
             Error::MissingHost => write!(f, "missing host in request URI"),
@@ -35,7 +38,7 @@ impl std::error::Error for Error {
         match self {
             Error::Connect(e) => Some(e),
             Error::Handshake(e) | Error::Request(e) => Some(e),
-            _ => None,
+            Error::ConnectionFailed | Error::ConnectTimeout | Error::MissingHost | Error::ConnectionNotReady => None,
         }
     }
 }

--- a/dpdk-net-util/src/lib.rs
+++ b/dpdk-net-util/src/lib.rs
@@ -39,7 +39,7 @@ pub mod error;
 pub mod executor;
 pub mod pool;
 
-pub use app::DpdkApp;
+pub use app::{DpdkApp, DpdkAppError};
 pub use client::{ClientConfig, DpdkHttpClient};
 pub use connect::{http1_connect, http2_connect};
 pub use connection::{Connection, HttpVersion, ResponseFuture};

--- a/dpdk-net-util/src/pool.rs
+++ b/dpdk-net-util/src/pool.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 
 use bytes::Bytes;
 use hyper::body::Incoming;
@@ -34,7 +34,7 @@ use crate::error::Error;
 pub struct ConnectionPool {
     reactor: ReactorHandle,
     config: ClientConfig,
-    connections: HashMap<(IpAddress, u16), Vec<Connection>>,
+    connections: HashMap<(IpAddress, u16), VecDeque<Connection>>,
     max_idle_per_host: usize,
 }
 
@@ -112,11 +112,11 @@ impl ConnectionPool {
 
         // Enforce limit by removing oldest idle connection.
         if conns.len() >= self.max_idle_per_host {
-            conns.remove(0);
+            conns.pop_front();
         }
 
-        conns.push(conn);
-        Ok(conns.last_mut().unwrap())
+        conns.push_back(conn);
+        Ok(conns.back_mut().unwrap())
     }
 
     /// Send a one-shot request, reusing a pooled connection if available.

--- a/dpdk-net/src/api/rte/eth.rs
+++ b/dpdk-net/src/api/rte/eth.rs
@@ -217,7 +217,7 @@ impl EthConf {
     /// Enable RSS mode with explicit Microsoft RSS key
     pub fn rss_with_key(mut self) -> Self {
         self.rx_mode.mq_mode = RxMqMode::Rss;
-        self.rss_hf = rss_hf::IP | rss_hf::TCP;
+        self.rss_hf = rss_hf::IP | rss_hf::TCP | rss_hf::UDP;
         self.rss_key = Some(RSS_KEY_40.to_vec());
         self
     }

--- a/dpdk-net/src/api/rte/queue.rs
+++ b/dpdk-net/src/api/rte/queue.rs
@@ -137,8 +137,7 @@ impl TxQueue {
 
         // Remove sent packets from the buffer.
         // We need to forget them since DPDK has taken ownership and will free them.
-        for _ in 0..sent {
-            let mbuf = mbufs.remove(0);
+        for mbuf in mbufs.drain(..sent as usize) {
             // Don't drop - DPDK owns the mbuf now
             std::mem::forget(mbuf);
         }

--- a/dpdk-net/src/device/arp_cache.rs
+++ b/dpdk-net/src/device/arp_cache.rs
@@ -193,8 +193,8 @@ pub fn build_arp_reply_for_injection(
     our_ip: Ipv4Addr,
     peer_mac: MacAddress,
     peer_ip: Ipv4Addr,
-) -> Vec<u8> {
-    let mut packet = vec![0u8; 42]; // Ethernet (14) + ARP (28)
+) -> [u8; 42] {
+    let mut packet = [0u8; 42]; // Ethernet (14) + ARP (28)
 
     // Ethernet header
     packet[0..6].copy_from_slice(&our_mac); // Destination MAC (us)

--- a/dpdk-net/src/device/dpdk_device.rs
+++ b/dpdk-net/src/device/dpdk_device.rs
@@ -266,6 +266,15 @@ impl Device for DpdkDevice {
     }
 
     fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+        // Pre-check: deny token if mempool is exhausted.
+        // This prevents the silent packet drop in consume()'s fallback path.
+        if self.mempool.avail_count() == 0 {
+            self.flush_tx(); // Try to free some mbufs by draining TX ring
+            if self.mempool.avail_count() == 0 {
+                return None;
+            }
+        }
+
         if self.tx_batch.len() < self.tx_batch.capacity() {
             Some(DpdkTxTokenWithPool {
                 mempool: &self.mempool,
@@ -323,7 +332,9 @@ impl<'a> phy::TxToken for DpdkTxTokenWithPool<'a> {
 
             result
         } else {
-            // Fallback if allocation fails - packet data is lost
+            // Mempool exhausted despite pre-check in transmit() — should be rare.
+            // We must still call f() since smoltcp expects it, but the packet is lost.
+            tracing::error!("TX mempool unexpectedly exhausted in consume(); packet dropped");
             let mut buffer = vec![0u8; len];
             f(&mut buffer)
         }

--- a/dpdk-net/src/runtime/mod.rs
+++ b/dpdk-net/src/runtime/mod.rs
@@ -55,5 +55,5 @@ mod traits;
 
 pub use reactor::{Reactor, ReactorHandle, ReactorInner};
 #[cfg(feature = "tokio")]
-pub use tokio_compat::{TokioRuntime, TokioTcpStream};
+pub use tokio_compat::{TokioRuntime, TokioTcpStream, TokioUdpSocket};
 pub use traits::Runtime;

--- a/dpdk-net/src/runtime/reactor.rs
+++ b/dpdk-net/src/runtime/reactor.rs
@@ -196,38 +196,36 @@ impl Reactor<DpdkDevice> {
     pub async fn run_with<R: Runtime>(self, batch_size: usize, cancel: Rc<Cell<bool>>) {
         while !cancel.get() {
             let timestamp = Instant::now();
-            let mut packets_processed = 0;
 
-            // Process ingress in batches
-            loop {
-                let result = {
-                    let mut inner = self.inner.borrow_mut();
-                    inner.poll_ingress_single(timestamp)
-                };
+            // Hold a single borrow for the entire poll cycle (ingress + egress + cleanup).
+            // This is safe because we are on a single-threaded LocalSet — socket futures
+            // can only poll after we yield, so no borrow contention is possible.
+            {
+                let mut inner = self.inner.borrow_mut();
+                let mut packets_processed = 0;
 
-                match result {
-                    PollIngressSingleResult::None => break,
-                    _ => {
-                        packets_processed += 1;
-                        if packets_processed >= batch_size {
-                            // Hit batch limit - break to run egress before yielding
-                            // This prevents DoS: we must send ACKs/responses, not just receive
-                            break;
+                // Process ingress in batches
+                loop {
+                    match inner.poll_ingress_single(timestamp) {
+                        PollIngressSingleResult::None => break,
+                        _ => {
+                            packets_processed += 1;
+                            if packets_processed >= batch_size {
+                                // Hit batch limit - break to run egress before yielding
+                                // This prevents DoS: we must send ACKs/responses, not just receive
+                                break;
+                            }
                         }
                     }
                 }
-            }
 
-            // Process egress (bounded work - just transmits queued packets)
-            {
-                let mut inner = self.inner.borrow_mut();
+                // Process egress (bounded work - just transmits queued packets)
                 inner.poll_egress(timestamp);
-            }
 
-            // Clean up orphaned closing sockets that have completed their handshake
-            {
-                let mut inner = self.inner.borrow_mut();
-                inner.cleanup_orphaned();
+                // Clean up orphaned closing sockets (skip if none pending)
+                if !inner.orphaned_closing.is_empty() {
+                    inner.cleanup_orphaned();
+                }
             }
 
             // Yield to let other async tasks run (accept handlers, recv futures, etc.)

--- a/dpdk-net/src/runtime/tokio_compat.rs
+++ b/dpdk-net/src/runtime/tokio_compat.rs
@@ -1,9 +1,11 @@
-//! Tokio compatibility wrappers for async TCP sockets.
+//! Tokio compatibility wrappers for async sockets.
 //!
 //! This module provides:
 //! - [`TokioRuntime`]: Implementation of the [`Runtime`](super::Runtime) trait for tokio
 //! - [`TokioTcpStream`]: A wrapper around [`TcpStream`](crate::socket::TcpStream) that implements
 //!   tokio's [`AsyncRead`](tokio::io::AsyncRead) and [`AsyncWrite`](tokio::io::AsyncWrite) traits
+//! - [`TokioUdpSocket`]: A wrapper around [`UdpSocket`](crate::socket::UdpSocket) providing
+//!   tokio-style async methods for datagram I/O
 //!
 //! # Example
 //!
@@ -23,8 +25,10 @@
 //! ```
 
 use super::Runtime;
-use crate::socket::TcpStream;
+use crate::socket::{TcpStream, UdpSocket};
 use smoltcp::socket::tcp::{self, RecvError, State};
+use smoltcp::socket::udp::{RecvError as UdpRecvError, SendError as UdpSendError, UdpMetadata};
+use smoltcp::wire::IpEndpoint;
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -138,18 +142,14 @@ impl AsyncWrite for TokioTcpStream {
 
     fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         let this = self.get_mut();
-        let inner = this.inner.reactor.borrow_mut();
-        let socket = inner.sockets.get::<tcp::Socket>(this.inner.handle);
+        let mut inner = this.inner.reactor.borrow_mut();
+        let socket = inner.sockets.get_mut::<tcp::Socket>(this.inner.handle);
 
         // smoltcp doesn't have explicit flush - data is sent when egress is polled.
         // We consider flush complete when the send buffer is empty.
         if socket.send_queue() == 0 {
             Poll::Ready(Ok(()))
         } else {
-            // Register waker to be notified when send buffer drains
-            drop(inner);
-            let mut inner = this.inner.reactor.borrow_mut();
-            let socket = inner.sockets.get_mut::<tcp::Socket>(this.inner.handle);
             socket.register_send_waker(cx.waker());
             Poll::Pending
         }
@@ -181,7 +181,7 @@ impl AsyncWrite for TokioTcpStream {
             match socket.state() {
                 State::Closed | State::TimeWait => Poll::Ready(Ok(())),
                 _ => {
-                    socket.register_send_waker(cx.waker());
+                    socket.register_recv_waker(cx.waker());
                     Poll::Pending
                 }
             }
@@ -192,5 +192,88 @@ impl AsyncWrite for TokioTcpStream {
 impl From<TcpStream> for TokioTcpStream {
     fn from(stream: TcpStream) -> Self {
         Self::new(stream)
+    }
+}
+
+/// A wrapper around [`UdpSocket`] providing tokio-style async methods.
+///
+/// Unlike [`TokioTcpStream`] which implements `AsyncRead`/`AsyncWrite` (stream
+/// protocols), UDP is datagram-based. This wrapper provides `send_to()` and
+/// `recv_from()` async methods that match tokio's `UdpSocket` API.
+///
+/// # Example
+///
+/// ```no_run
+/// use dpdk_net::socket::UdpSocket;
+/// use dpdk_net::runtime::tokio_compat::TokioUdpSocket;
+/// use smoltcp::wire::IpEndpoint;
+///
+/// async fn example(socket: UdpSocket) {
+///     let socket = TokioUdpSocket::new(socket);
+///     let mut buf = [0u8; 1500];
+///     let (n, meta) = socket.recv_from(&mut buf).await.unwrap();
+///     socket.send_to(&buf[..n], meta.endpoint).await.unwrap();
+/// }
+/// ```
+pub struct TokioUdpSocket {
+    inner: UdpSocket,
+}
+
+impl TokioUdpSocket {
+    /// Create a new tokio-compatible wrapper around a [`UdpSocket`].
+    pub fn new(socket: UdpSocket) -> Self {
+        Self { inner: socket }
+    }
+
+    /// Get a reference to the underlying [`UdpSocket`].
+    pub fn get_ref(&self) -> &UdpSocket {
+        &self.inner
+    }
+
+    /// Get a mutable reference to the underlying [`UdpSocket`].
+    pub fn get_mut(&mut self) -> &mut UdpSocket {
+        &mut self.inner
+    }
+
+    /// Consume this wrapper and return the underlying [`UdpSocket`].
+    pub fn into_inner(self) -> UdpSocket {
+        self.inner
+    }
+
+    /// Set the default remote endpoint (connected mode).
+    pub fn connect(&mut self, endpoint: IpEndpoint) {
+        self.inner.connect(endpoint);
+    }
+
+    /// Send a datagram to the specified endpoint.
+    pub async fn send_to(&self, data: &[u8], endpoint: IpEndpoint) -> Result<usize, UdpSendError> {
+        self.inner.send_to(data, endpoint).await
+    }
+
+    /// Send a datagram to the connected endpoint.
+    ///
+    /// # Panics
+    /// Panics if [`connect`](Self::connect) was not called first.
+    pub async fn send(&self, data: &[u8]) -> Result<usize, UdpSendError> {
+        self.inner.send(data).await
+    }
+
+    /// Receive a datagram, returning bytes read and source metadata.
+    pub async fn recv_from(
+        &self,
+        buf: &mut [u8],
+    ) -> Result<(usize, UdpMetadata), UdpRecvError> {
+        self.inner.recv_from(buf).await
+    }
+
+    /// Receive a datagram, returning only the number of bytes read.
+    pub async fn recv(&self, buf: &mut [u8]) -> Result<usize, UdpRecvError> {
+        self.inner.recv(buf).await
+    }
+}
+
+impl From<UdpSocket> for TokioUdpSocket {
+    fn from(socket: UdpSocket) -> Self {
+        Self::new(socket)
     }
 }

--- a/dpdk-net/src/socket/mod.rs
+++ b/dpdk-net/src/socket/mod.rs
@@ -18,7 +18,7 @@ pub use tcp::{
     AcceptFuture, CloseFuture, TcpListener, TcpRecvFuture, TcpSendFuture, TcpStream,
     WaitConnectedFuture,
 };
-pub use udp::{UdpRecvFuture, UdpSendFuture, UdpSocket};
+pub use udp::{UdpRecvByteFuture, UdpRecvFuture, UdpSendFuture, UdpSocket};
 
 // Re-export smoltcp error types for convenience
 pub use smoltcp::socket::tcp::{ConnectError, ListenError};

--- a/dpdk-net/src/socket/tcp.rs
+++ b/dpdk-net/src/socket/tcp.rs
@@ -189,6 +189,16 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
+    /// Default receive buffer size (16KB).
+    pub const DEFAULT_RX_BUFFER: usize = 16384;
+    /// Default transmit buffer size (16KB).
+    pub const DEFAULT_TX_BUFFER: usize = 16384;
+
+    /// Creates a new TcpListener with default buffer sizes (16KB rx/tx) and backlog of 2.
+    pub fn bind_default(handle: &ReactorHandle, port: u16) -> Result<Self, ListenError> {
+        Self::bind(handle, port, Self::DEFAULT_RX_BUFFER, Self::DEFAULT_TX_BUFFER)
+    }
+
     /// Creates a new TcpListener bound to the specified port with default backlog of 2.
     ///
     /// Similar to `std::net::TcpListener::bind()`.
@@ -485,14 +495,14 @@ impl<'a> Future for WaitConnectedFuture<'a> {
             State::Established => Poll::Ready(Ok(())),
             // Connection failed
             State::Closed | State::TimeWait => Poll::Ready(Err(())),
-            // Still connecting - register waker and wait
+            // Still connecting - register waker and wait for inbound SYN-ACK
             State::SynSent | State::SynReceived => {
-                socket.register_send_waker(cx.waker());
+                socket.register_recv_waker(cx.waker());
                 Poll::Pending
             }
-            // Other states - keep waiting
+            // Other states - keep waiting for inbound state transition
             _ => {
-                socket.register_send_waker(cx.waker());
+                socket.register_recv_waker(cx.waker());
                 Poll::Pending
             }
         }
@@ -514,9 +524,9 @@ impl<'a> Future for CloseFuture<'a> {
         match socket.state() {
             // Fully closed - done!
             State::Closed | State::TimeWait => Poll::Ready(()),
-            // Still closing - register waker and wait
+            // Still closing - register waker and wait for inbound FIN-ACK
             _ => {
-                socket.register_send_waker(cx.waker());
+                socket.register_recv_waker(cx.waker());
                 Poll::Pending
             }
         }

--- a/dpdk-net/src/socket/udp.rs
+++ b/dpdk-net/src/socket/udp.rs
@@ -18,12 +18,37 @@ use std::task::{Context, Poll};
 ///
 /// Unlike TCP, UDP is connectionless. You can send to and receive from
 /// any endpoint without establishing a connection first.
+///
+/// # Connected mode
+///
+/// After calling [`connect`](Self::connect), you can use [`send`](Self::send)
+/// and [`recv`](Self::recv) which operate on the connected endpoint.
 pub struct UdpSocket {
     handle: SocketHandle,
     reactor: Rc<RefCell<ReactorInner<DpdkDevice>>>,
+    /// Connected peer endpoint (set by `connect()`).
+    peer: Option<IpEndpoint>,
 }
 
 impl UdpSocket {
+    /// Default number of receive buffer packets.
+    pub const DEFAULT_RX_BUFFER_PACKETS: usize = 64;
+    /// Default number of transmit buffer packets.
+    pub const DEFAULT_TX_BUFFER_PACKETS: usize = 64;
+    /// Default maximum packet size (covers standard MTU + headers).
+    pub const DEFAULT_MAX_PACKET_SIZE: usize = 1536;
+
+    /// Creates a new UDP socket with default buffer sizes (64 packets, 1536 bytes each).
+    pub fn bind_default(handle: &ReactorHandle, port: u16) -> Result<Self, BindError> {
+        Self::bind(
+            handle,
+            port,
+            Self::DEFAULT_RX_BUFFER_PACKETS,
+            Self::DEFAULT_TX_BUFFER_PACKETS,
+            Self::DEFAULT_MAX_PACKET_SIZE,
+        )
+    }
+
     /// Creates a new UDP socket bound to the specified port.
     ///
     /// # Arguments
@@ -58,6 +83,7 @@ impl UdpSocket {
         Ok(UdpSocket {
             handle: socket_handle,
             reactor: handle.inner.clone(),
+            peer: None,
         })
     }
 
@@ -80,6 +106,30 @@ impl UdpSocket {
         socket.endpoint()
     }
 
+    /// Set the default remote endpoint (connected mode).
+    ///
+    /// After calling this, [`send`](Self::send) and [`recv`](Self::recv) can
+    /// be used instead of [`send_to`](Self::send_to) and [`recv_from`](Self::recv_from).
+    pub fn connect(&mut self, endpoint: IpEndpoint) {
+        self.peer = Some(endpoint);
+    }
+
+    /// Get the connected peer endpoint, if any.
+    pub fn peer_endpoint(&self) -> Option<IpEndpoint> {
+        self.peer
+    }
+
+    /// Send a datagram to the connected endpoint asynchronously.
+    ///
+    /// # Panics
+    /// Panics if [`connect`](Self::connect) was not called first.
+    pub fn send<'a>(&'a self, data: &'a [u8]) -> UdpSendFuture<'a> {
+        let endpoint = self
+            .peer
+            .expect("UdpSocket not connected; call connect() first");
+        self.send_to(data, endpoint)
+    }
+
     /// Send a datagram to the specified endpoint asynchronously.
     ///
     /// Returns the number of bytes sent when the operation completes.
@@ -89,6 +139,14 @@ impl UdpSocket {
             data,
             endpoint,
         }
+    }
+
+    /// Receive a datagram asynchronously, discarding the source metadata.
+    ///
+    /// This is a convenience wrapper for connected-mode usage. Returns only
+    /// the number of bytes received.
+    pub fn recv<'a>(&'a self, buf: &'a mut [u8]) -> UdpRecvByteFuture<'a> {
+        UdpRecvByteFuture { socket: self, buf }
     }
 
     /// Receive a datagram asynchronously.
@@ -141,7 +199,7 @@ impl Future for UdpSendFuture<'_> {
     }
 }
 
-/// Future for receiving UDP data
+/// Future for receiving UDP data with metadata
 pub struct UdpRecvFuture<'a> {
     socket: &'a UdpSocket,
     buf: &'a mut [u8],
@@ -158,6 +216,30 @@ impl Future for UdpRecvFuture<'_> {
             Ok((len, metadata)) => Poll::Ready(Ok((len, metadata))),
             Err(RecvError::Exhausted) => {
                 // No data available, register waker and wait
+                socket.register_recv_waker(cx.waker());
+                Poll::Pending
+            }
+            Err(e) => Poll::Ready(Err(e)),
+        }
+    }
+}
+
+/// Future for receiving UDP data without metadata (connected-mode convenience)
+pub struct UdpRecvByteFuture<'a> {
+    socket: &'a UdpSocket,
+    buf: &'a mut [u8],
+}
+
+impl Future for UdpRecvByteFuture<'_> {
+    type Output = Result<usize, RecvError>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut inner = self.socket.reactor.borrow_mut();
+        let socket = inner.sockets.get_mut::<udp::Socket>(self.socket.handle);
+
+        match socket.recv_slice(self.buf) {
+            Ok((len, _metadata)) => Poll::Ready(Ok(len)),
+            Err(RecvError::Exhausted) => {
                 socket.register_recv_waker(cx.waker());
                 Poll::Pending
             }

--- a/tests/dpdk-bench-client/src/main.rs
+++ b/tests/dpdk-bench-client/src/main.rs
@@ -1,6 +1,6 @@
-//! HTTP benchmark client similar to wrk
+//! HTTP/UDP benchmark client similar to wrk
 //!
-//! A high-performance HTTP benchmark tool for testing DPDK-based servers.
+//! A high-performance benchmark tool for testing DPDK-based servers.
 //!
 //! # Usage
 //!
@@ -11,11 +11,16 @@
 //! # Hyper mode (supports HTTP/2)
 //! dpdk-bench-client --mode hyper -c 100 -d 30s http://10.0.0.4:8080/
 //! dpdk-bench-client --mode hyper --http2 -c 100 -d 30s http://10.0.0.4:8080/
+//!
+//! # UDP echo mode (measures PPS, RTT, loss)
+//! dpdk-bench-client --mode udp -c 10 -d 10s 10.0.0.4:8080
+//! dpdk-bench-client --mode udp -c 10 -d 10s --packet-size 1024 10.0.0.4:8080
 //! ```
 
 mod hyper_client;
 mod raw_client;
 mod stats;
+mod udp_client;
 
 use clap::{Parser, ValueEnum};
 use serde::Serialize;
@@ -30,6 +35,8 @@ enum ClientMode {
     Raw,
     /// Hyper-based client with HTTP/2 support
     Hyper,
+    /// UDP echo client for measuring PPS, RTT, and loss
+    Udp,
 }
 
 #[derive(Parser, Debug)]
@@ -63,6 +70,10 @@ struct Args {
     /// Request timeout in milliseconds
     #[arg(long, default_value = "5000")]
     timeout: u64,
+
+    /// UDP packet size in bytes (only for udp mode, min 16)
+    #[arg(long, default_value = "64")]
+    packet_size: usize,
 }
 
 /// Parse duration string like "10s", "1m", "500ms"
@@ -109,8 +120,8 @@ async fn main() {
     let duration = parse_duration(&args.duration).expect("Invalid duration format");
     let timeout = Duration::from_millis(args.timeout);
 
-    // Warn if HTTP/2 requested with raw mode
-    if args.http2 && matches!(args.mode, ClientMode::Raw) {
+    // Warn if HTTP/2 requested with incompatible mode
+    if args.http2 && !matches!(args.mode, ClientMode::Hyper) {
         eprintln!("Warning: --http2 is only supported with --mode hyper, ignoring");
     }
 
@@ -127,6 +138,7 @@ async fn main() {
                 "hyper (HTTP/1.1)"
             }
         }
+        ClientMode::Udp => "udp",
     };
 
     let stats = Arc::new(BenchStats::new());
@@ -150,6 +162,19 @@ async fn main() {
                 duration,
                 timeout,
                 args.http2,
+                stats.clone(),
+            )
+            .await;
+        }
+        ClientMode::Udp => {
+            // For UDP mode, url is used as "host:port" target address
+            let target = args.url.strip_prefix("udp://").unwrap_or(&args.url);
+            udp_client::run_benchmark(
+                target,
+                args.connections,
+                duration,
+                timeout,
+                args.packet_size,
                 stats.clone(),
             )
             .await;

--- a/tests/dpdk-bench-client/src/udp_client.rs
+++ b/tests/dpdk-bench-client/src/udp_client.rs
@@ -1,0 +1,111 @@
+//! UDP echo benchmark client
+//!
+//! Sends datagrams to a UDP echo server and measures PPS, RTT, and loss.
+//! Each datagram contains a 16-byte header (8-byte sequence + 8-byte timestamp)
+//! followed by padding to reach the configured packet size.
+
+use crate::stats::{BenchStats, LocalStats};
+use std::sync::Arc;
+use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+use tokio::net::UdpSocket;
+
+/// Run the UDP echo benchmark
+pub async fn run_benchmark(
+    target: &str,
+    sockets: usize,
+    duration: Duration,
+    timeout: Duration,
+    packet_size: usize,
+    stats: Arc<BenchStats>,
+) {
+    let end_time = Instant::now() + duration;
+
+    let mut handles = Vec::with_capacity(sockets);
+    for _ in 0..sockets {
+        let target = target.to_string();
+        let stats = stats.clone();
+
+        let handle = tokio::spawn(async move {
+            run_socket(target, stats, end_time, timeout, packet_size).await;
+        });
+        handles.push(handle);
+    }
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+}
+
+async fn run_socket(
+    target: String,
+    stats: Arc<BenchStats>,
+    end_time: Instant,
+    timeout: Duration,
+    packet_size: usize,
+) {
+    stats.active_connections.fetch_add(1, Ordering::Relaxed);
+
+    let socket = match UdpSocket::bind("0.0.0.0:0").await {
+        Ok(s) => s,
+        Err(e) => {
+            stats.record_error_sample(format!("bind: {}", e));
+            stats.active_connections.fetch_sub(1, Ordering::Relaxed);
+            return;
+        }
+    };
+
+    if let Err(e) = socket.connect(&target).await {
+        stats.record_error_sample(format!("connect: {}", e));
+        stats.active_connections.fetch_sub(1, Ordering::Relaxed);
+        return;
+    }
+
+    let mut local = LocalStats::new();
+    let pkt_size = packet_size.max(16); // minimum 16 bytes for header
+    let mut send_buf = vec![0u8; pkt_size];
+    let mut recv_buf = vec![0u8; pkt_size + 64]; // extra room for safety
+    let mut seq: u64 = 0;
+
+    while Instant::now() < end_time {
+        // Encode header: [seq:8][timestamp_nanos:8]
+        let send_time = Instant::now();
+        send_buf[..8].copy_from_slice(&seq.to_le_bytes());
+
+        // Use elapsed since epoch-like anchor for the timestamp
+        let ts_nanos = send_time.elapsed().as_nanos() as u64;
+        send_buf[8..16].copy_from_slice(&ts_nanos.to_le_bytes());
+
+        // Send
+        match socket.send(&send_buf).await {
+            Ok(_) => {}
+            Err(e) => {
+                local.record_error();
+                stats.record_error_sample(format!("send: {}", e));
+                seq += 1;
+                continue;
+            }
+        }
+
+        // Receive with timeout
+        match tokio::time::timeout(timeout, socket.recv(&mut recv_buf)).await {
+            Ok(Ok(n)) => {
+                let latency_us = send_time.elapsed().as_micros() as u64;
+                local.record_success(latency_us, n);
+            }
+            Ok(Err(e)) => {
+                local.record_error();
+                stats.record_error_sample(format!("recv: {}", e));
+            }
+            Err(_) => {
+                local.record_error();
+                // Don't log every timeout - too noisy
+            }
+        }
+
+        seq += 1;
+    }
+
+    local.merge_into(&stats);
+    stats.active_connections.fetch_sub(1, Ordering::Relaxed);
+}

--- a/tests/dpdk-bench-server/src/main.rs
+++ b/tests/dpdk-bench-server/src/main.rs
@@ -1,18 +1,23 @@
-//! HTTP Benchmark Server - DPDK, Tokio, or Kimojio
+//! Benchmark Server - DPDK, Tokio, or Kimojio
 //!
-//! A high-performance HTTP server for benchmarking, supporting DPDK, Tokio, and Kimojio backends.
+//! A high-performance server for benchmarking, supporting DPDK, Tokio, and Kimojio backends.
 //!
-//! Supports four modes:
+//! Supports six modes:
 //! - **dpdk**: Multi-queue DPDK + smoltcp + hyper (requires root, hardware NIC)
 //! - **tokio**: Standard tokio + hyper with multi-threaded runtime (works anywhere)
 //! - **tokio-local**: Thread-per-core tokio + hyper with CPU pinning (works anywhere)
 //! - **kimojio**: Thread-per-core io_uring + custom HTTP parser (Linux 5.15+)
+//! - **kimojio-poll**: Same as kimojio with busy polling (Linux 5.15+)
+//! - **udp-echo**: Multi-queue DPDK UDP echo server (requires root, hardware NIC)
 //!
 //! # Usage
 //!
 //! ```bash
-//! # DPDK mode (requires sudo)
+//! # DPDK HTTP mode (requires sudo)
 //! sudo -E dpdk-bench-server --mode dpdk
+//!
+//! # DPDK UDP echo mode (requires sudo)
+//! sudo -E dpdk-bench-server --mode udp-echo
 //!
 //! # Tokio mode (no sudo needed)
 //! dpdk-bench-server --mode tokio
@@ -32,6 +37,7 @@
 //! ```bash
 //! curl http://localhost:8080/
 //! dpdk-bench-client -c 10 -d 10s http://localhost:8080/
+//! dpdk-bench-client --mode udp -c 10 -d 10s 10.0.0.4:8080
 //! ```
 
 use std::net::SocketAddr;
@@ -60,6 +66,8 @@ enum ServerMode {
     Kimojio,
     /// Thread-per-core kimojio + io_uring with busy polling (Linux 5.15+)
     KimojioPoll,
+    /// DPDK UDP echo server (requires root and hardware NIC)
+    UdpEcho,
 }
 
 #[derive(Parser, Debug)]
@@ -257,6 +265,91 @@ fn run_dpdk_server(
         });
 }
 
+/// Run the DPDK-based UDP echo server
+fn run_udp_echo_server(
+    interface: &str,
+    port: u16,
+    max_queues: Option<usize>,
+    ip_addr: Option<&str>,
+    gateway: Option<&str>,
+    hw_queues: Option<usize>,
+) {
+    use dpdk_net::api::rte::eal::EalBuilder;
+    use dpdk_net::socket::UdpSocket;
+    use dpdk_net_test::manual::tcp::{get_default_gateway, get_interface_ipv4, get_pci_addr};
+    use dpdk_net_util::{DpdkApp, WorkerContext};
+    use smoltcp::wire::Ipv4Address;
+    use tracing::warn;
+
+    let ip = if let Some(ip_str) = ip_addr {
+        Ipv4Address::from_str(ip_str).expect("Invalid IP address")
+    } else {
+        get_interface_ipv4(interface).expect("Failed to get IP address for interface")
+    };
+    let gw = if let Some(gw_str) = gateway {
+        Ipv4Address::from_str(gw_str).expect("Invalid gateway")
+    } else {
+        get_default_gateway().unwrap_or(Ipv4Address::new(10, 0, 0, 1))
+    };
+
+    let num_queues = if let Some(queues) = hw_queues {
+        queues
+    } else {
+        dpdk_net_test::util::get_ethtool_channels(interface)
+            .map(|ch| ch.combined_count as usize)
+            .expect("Failed to get hardware queues via ethtool")
+    };
+    let num_queues = if let Some(max) = max_queues {
+        num_queues.min(max)
+    } else {
+        num_queues
+    };
+    let core_list = format!("0-{}", num_queues.saturating_sub(1));
+
+    let pci_addr = get_pci_addr(interface).expect("Failed to get PCI address");
+    let _eal = EalBuilder::new()
+        .allow(&pci_addr)
+        .core_list(&core_list)
+        .init()
+        .expect("Failed to initialize EAL");
+
+    let cancel = tokio_util::sync::CancellationToken::new();
+    let cancel_clone = cancel.clone();
+    ctrlc::set_handler(move || {
+        warn!("Received Ctrl+C, shutting down");
+        cancel_clone.cancel();
+    })
+    .expect("Failed to set Ctrl+C handler");
+
+    info!(port, queues = num_queues, "Starting UDP echo server");
+
+    DpdkApp::new()
+        .eth_dev(0)
+        .ip(ip)
+        .gateway(gw)
+        .run(move |ctx: WorkerContext| {
+            let cancel = cancel.clone();
+            async move {
+                let socket = UdpSocket::bind_default(&ctx.reactor, port)
+                    .expect("Failed to bind UDP socket");
+                info!(queue = ctx.queue_id, port, "UDP echo server listening");
+
+                let mut buf = vec![0u8; 65535];
+                loop {
+                    tokio::select! {
+                        _ = cancel.cancelled() => break,
+                        result = socket.recv_from(&mut buf) => {
+                            if let Ok((n, meta)) = result {
+                                let _ = socket.send_to(&buf[..n], meta.endpoint).await;
+                                REQUEST_COUNT.fetch_add(1, Ordering::Relaxed);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+}
+
 fn main() {
     // Initialize tracing - respects RUST_LOG, defaults to info if not set
     // Disable ANSI colors for clean log output
@@ -323,6 +416,26 @@ fn main() {
                 "Starting HTTP benchmark server with busy polling"
             );
             run_kimojio_thread_per_core_server(args.port, counter_handler_kimojio, true);
+        }
+        ServerMode::UdpEcho => {
+            info!(
+                mode = "udp-echo",
+                interface = %args.interface,
+                port = args.port,
+                ip_addr = ?args.ip_addr,
+                gateway = ?args.gateway,
+                hw_queues = ?args.hw_queues,
+                max_queues = args.max_queues,
+                "Starting UDP echo server"
+            );
+            run_udp_echo_server(
+                &args.interface,
+                args.port,
+                args.max_queues,
+                args.ip_addr.as_deref(),
+                args.gateway.as_deref(),
+                args.hw_queues,
+            );
         }
     }
 }


### PR DESCRIPTION
Fix critical bugs: enable Tokio time driver, fix silent TX packet drops on mempool exhaustion, fix wrong waker types in TCP futures (WaitConnected/Close/poll_shutdown), and eliminate double borrow in poll_flush.

Optimize performance: batch borrow in reactor poll loop, use drain() for TX queue, VecDeque for connection pool, and stack array for ARP injection.

Improve API ergonomics: add DpdkApp::try_run() with proper error handling, configurable subnet prefix, ephemeral port allocation in WorkerContext, and bind_default() convenience methods for TCP/UDP.

Add comprehensive UDP support: connected mode (connect/send/recv), TokioUdpSocket wrapper, RSS hash flags for UDP multi-queue, UDP echo benchmark server mode, UDP benchmark client measuring PPS/RTT/loss, and end-to-end UDP integration tests.

Enforce connect_timeout in DpdkHttpClient using tokio::time::timeout().