### PR TITLE
feat(compatible): Use the libc library to improve compatibility.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -564,6 +564,7 @@ dependencies = [
  "arrayvec",
  "dpdk-net-sys",
  "futures-io",
+ "libc",
  "nix",
  "smoltcp",
  "tracing",
@@ -1212,9 +1213,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"

--- a/dpdk-net/Cargo.toml
+++ b/dpdk-net/Cargo.toml
@@ -17,3 +17,6 @@ futures-io.workspace = true
 dpdk-net-sys.workspace = true
 tracing.workspace = true
 arc-swap.workspace = true
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2.186"

--- a/dpdk-net/src/api/rte/eal.rs
+++ b/dpdk-net/src/api/rte/eal.rs
@@ -333,6 +333,12 @@ impl Eal {
             .collect();
 
         let argc = args.len() as i32;
+        #[cfg(target_os = "linux")]
+        let mut argv: Vec<*mut libc::c_char> = args
+            .iter()
+            .map(|s| s.as_ptr() as *mut libc::c_char)
+            .collect();
+        #[cfg(not(target_os = "linux"))]
         let mut argv: Vec<*mut i8> = args.iter().map(|s| s.as_ptr() as *mut i8).collect();
         argv.push(std::ptr::null_mut());
 
@@ -379,7 +385,10 @@ where
         .map(|s| CString::new(s.as_ref()).expect("argument contains null byte"))
         .collect();
     let argc = args.len() as i32;
-    let mut argv: Vec<*mut i8> = args.iter().map(|s| s.as_ptr() as *mut i8).collect();
+    let mut argv: Vec<*mut libc::c_char> = args
+        .iter()
+        .map(|s| s.as_ptr() as *mut libc::c_char)
+        .collect();
     argv.push(std::ptr::null_mut());
     let ret = unsafe { dpdk_net_sys::ffi::rte_eal_init(argc, argv.as_mut_ptr()) };
     check_rte_success(ret)


### PR DESCRIPTION
Using libc to resolve compatibility issues, on the `amd64` platform, like build target `aarch64-unknown-linux-gnu`  std::os::raw::c_char is u8, which can cause type mismatch problems.

```rust
 pub fn rte_eal_init(argc: ::std::os::raw::c_int, argv: *mut *mut ::std::os::raw::c_char) -> ::std::os::raw::c_int;
```

The code generated by bingds will consistently use `std::os::raw::c_char`, leading to the compiler error:
````shell
411 |     let ret = unsafe { dpdk_net_sys::ffi::rte_eal_init(argc, argv.as_mut_ptr()) };
    |                        -------------------------------       ^^^^^^^^^^^^^^^^^ expected `*mut *mut u8`, found `*mut *mut i8`
    |                        |
    |                        arguments to this function are incorrect
    |
    = note: expected raw pointer `*mut *mut u8`
               found raw pointer `*mut *mut i8`
```